### PR TITLE
championship: group: max 10s for the correction

### DIFF
--- a/championship/group.html
+++ b/championship/group.html
@@ -83,7 +83,7 @@
         const data = module.default;
 
         const TIMESTAMPED_LINE_AMOUNT = 10; // ! CHANGE IN THE tester.py FILE TOO IF YOU CHANGE THIS !
-        const TIMEOUTS = [2, 20];           // ! CHANGE IN THE tester.py FILE TOO IF YOU CHANGE THIS !
+        const TIMEOUTS = [2, 10];           // ! CHANGE IN THE tester.py FILE TOO IF YOU CHANGE THIS !
 
         // Hash function for grouping
         function hashCode(str) {


### PR DESCRIPTION
Apparently this value has been changed on the server validating the different projects. So align this here.

(c.f. discussion on the chat)